### PR TITLE
Correct typo: Missing 'i' in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To start with, follow the steps below:
 
 ## Documentation
 
-The documentation about the plugin can be found in [PLUGIN_SPECIFICATON.md](PLUGIN_SPECIFICATION.md). It includes the smart contracts and functions supported by the plugin.
+The documentation about the plugin can be found in [PLUGIN_SPECIFICATION.md](PLUGIN_SPECIFICATION.md). It includes the smart contracts and functions supported by the plugin.
 
 ## Formatting
 


### PR DESCRIPTION
PLUGIN_SPECIFICATON-PLUGIN_SPECIFICATION

(The letter "i" was missing)